### PR TITLE
0.8.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 GCCLIB Change LOG
 =================
 
+0.8.0-  4 Oct 2020
 F0044 - Fix for __ZONE when HRC700DK not installed
 F0043 - Fix for Calltype 5 allocation (double word not fullword)
       - cmssys.assemble

--- a/cmssys.h
+++ b/cmssys.h
@@ -8,7 +8,7 @@
 #ifndef CMSSYS_INCLUDED
 #define CMSSYS_INCLUDED
 
-#define GCCLIB_VERSION "F0044"
+#define GCCLIB_VERSION "0.8.0"
 
 #include <stddef.h>
 #include <stdarg.h>


### PR DESCRIPTION
```
0.8.0-  4 Oct 2020
F0044 - Fix for __ZONE when HRC700DK not installed
F0043 - Fix for Calltype 5 allocation (double word not fullword)
      - cmssys.assemble
        __STACKN entry point to call the SENTRIES command provided by HRC406DS
        __ZONE entry point to return the time zone offset from GMT in seconds
      - time.c use __ZONE to get local time
F0042 - Fix for Calltype 5 without a return buffer
        Fix for CMSargc() return type
        Fix for tstarg2 CMSplist() casting
F0041 - REXXSAA RexxVariablePool
```